### PR TITLE
Fix that http head is not set during negotiate

### DIFF
--- a/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/HttpClientTransport.java
+++ b/signalr-client-sdk/src/main/java/microsoft/aspnet/signalr/client/transport/HttpClientTransport.java
@@ -61,6 +61,7 @@ public abstract class HttpClientTransport implements ClientTransport {
 
         Request get = new Request(Constants.HTTP_GET);
         get.setUrl(url);
+        get.setHeaders(connection.getHeaders());
         get.setVerb(Constants.HTTP_GET);
 
         connection.prepareRequest(get);


### PR DESCRIPTION
Fix possible `Unrecognized user identity. The user identity cannot change during an active SignalR connection.` when http head is used for auth.